### PR TITLE
Set 'cpoptions' to handle Vimscript line continuations

### DIFF
--- a/ftplugin/jsond.vim
+++ b/ftplugin/jsond.vim
@@ -9,6 +9,9 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
+let s:cpo_save = &cpo
+set cpo&vim
+
 " Enable auto begin new comment line when continuing from an old comment line
 setlocal comments=:;;;;,:;;;,:;;,:;
 setlocal formatoptions+=r
@@ -24,3 +27,6 @@ let b:undo_ftplugin =
       \  "setlocal comments< formatoptions<"
       \. " | setlocal commentstring<"
       \. " | unlet! b:ale_linter_aliases"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/jsond.vim
+++ b/ftplugin/jsond.vim
@@ -2,7 +2,7 @@
 " Language:     Racket (#lang jsond)
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
-" Last Change: 2022 Aug 12
+" Last Change:  2022 Aug 29
 
 if exists("b:did_ftplugin")
   finish

--- a/ftplugin/racket-info.vim
+++ b/ftplugin/racket-info.vim
@@ -9,6 +9,9 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
+let s:cpo_save = &cpo
+set cpo&vim
+
 " quick hack to allow adding values
 setlocal iskeyword=@,!,#-',*-:,<-Z,a-z,~,_,94
 
@@ -69,3 +72,6 @@ endif
 let b:ale_linter_aliases = ['racket']
 
 let b:undo_ftplugin .= " | unlet! b:ale_linter_aliases"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/racket-info.vim
+++ b/ftplugin/racket-info.vim
@@ -2,7 +2,7 @@
 " Language:     Racket (#lang info)
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
-" Last Change: 2022 Aug 12
+" Last Change:  2022 Aug 29
 
 if exists("b:did_ftplugin")
   finish

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -10,6 +10,9 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
+let s:cpo_save = &cpo
+set cpo&vim
+
 " quick hack to allow adding values
 setlocal iskeyword=@,!,#-',*-:,<-Z,a-z,~,_,94
 
@@ -74,3 +77,5 @@ if exists("loaded_matchit") && !exists("b:match_words")
   let b:undo_ftplugin .= " | unlet! b:match_words"
 endif
 
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -67,8 +67,9 @@ if !exists("no_plugin_maps") && !exists("no_racket_maps")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Racket Source Files (*.rkt *.rktl)\t*.rkt;*.rktl\n" .
-        \              "All Files (*.*)\t*.*\n"
+  let b:browsefilter =
+        \  "Racket Source Files (*.rkt *.rktl)\t*.rkt;*.rktl\n"
+        \. "All Files (*.*)\t*.*\n"
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -3,7 +3,7 @@
 " Maintainer:           D. Ben Knoble <ben.knoble+github@gmail.com>
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
-" Last Change: 2022 Aug 12
+" Last Change:          2022 Aug 29
 
 if exists("b:did_ftplugin")
   finish


### PR DESCRIPTION
- Set and restore 'cpoptions' to allow for line continuations
- Use prevailing line continuation style when setting b:browsefilter
- Update Last Change header
