### PR TITLE
Fix error: access to unitialized variable when vim9script unavailable…

### DIFF
--- a/indent/racket.vim
+++ b/indent/racket.vim
@@ -66,4 +66,9 @@ setlocal lispwords+=if-view,case-view,cond-view,list-view,dyn-view
 setlocal lispwords+=case/dep
 setlocal lispwords+=define/obs
 
-let b:undo_indent = "setlocal indentexpr< lisp< lispoptions< ai< si< lw<"
+
+let b:undo_indent = "setlocal indentexpr< lisp< ai< si< lw<"
+
+if has('vim9script')
+    let b:undo_indent .= " lispoptions<"
+endif


### PR DESCRIPTION
… (e.g. nvim)

lispoptions only got initialized when vim9script, but later accessed indiscriminately